### PR TITLE
Add ability to execute MinVer as global tool and fallback logic

### DIFF
--- a/Cake.MinVer.sln.DotSettings
+++ b/Cake.MinVer.sln.DotSettings
@@ -5,6 +5,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArgumentsStyleLiteral/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArgumentsStyleNamedExpression/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArgumentsStyleStringLiteral/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTrailingCommaInMultilineLists/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CommentTypo/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MarkupAttributeTypo/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MarkupTextTypo/@EntryIndexedValue">DO_NOT_SHOW</s:String>

--- a/src/Cake.MinVer/MinVerGlobalTool.cs
+++ b/src/Cake.MinVer/MinVerGlobalTool.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.MinVer
+{
+    internal class MinVerGlobalTool : MinVerToolBase
+    {
+        public MinVerGlobalTool(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools,
+            ICakeLog log) : base(fileSystem, environment, processRunner, tools, log)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override ProcessArgumentBuilder GetArguments(MinVerSettings settings)
+        {
+            var command = new ProcessArgumentBuilder();
+            var args = CreateArgumentBuilder(settings);
+
+            if (!args.IsNullOrEmpty())
+            {
+                args.CopyTo(command);
+            }
+
+            CakeLog.Verbose("{0} arguments: {1}", GetToolName(), args.RenderSafe());
+
+            return command;
+        }
+
+        /// <inheritdoc />
+        protected override string GetToolName()
+        {
+            return "MinVer Global Tool (minver)";
+        }
+
+        /// <inheritdoc />
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new [] { "minver", "minver.exe" };
+        }
+    }
+}

--- a/src/Cake.MinVer/MinVerLocalTool.cs
+++ b/src/Cake.MinVer/MinVerLocalTool.cs
@@ -1,0 +1,43 @@
+﻿using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.MinVer
+{
+    internal class MinVerLocalTool : MinVerToolBase
+    {
+        public MinVerLocalTool(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools,
+            ICakeLog log) : base(fileSystem, environment, processRunner, tools, log)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override ProcessArgumentBuilder GetArguments(MinVerSettings settings)
+        {
+            var command = new ProcessArgumentBuilder();
+            var args = CreateArgumentBuilder(settings);
+
+            command.Append("minver");
+
+            if (!args.IsNullOrEmpty())
+            {
+                args.CopyTo(command);
+            }
+
+            CakeLog.Verbose("{0} arguments: {1}", GetToolName(), args.RenderSafe());
+
+            return command;
+        }
+
+        /// <inheritdoc />
+        protected override string GetToolName()
+        {
+            return "MinVer Local Tool (dotnet minver)";
+        }
+    }
+}

--- a/src/Cake.MinVer/MinVerSettings.cs
+++ b/src/Cake.MinVer/MinVerSettings.cs
@@ -48,6 +48,30 @@ namespace Cake.MinVer
         public string TagPrefix { get; set; }
 
         /// <summary>
+        /// By default, MinVer is executed as a local tool first and, in case of error, fallback(*) to global tool
+        /// Set <see cref="PreferGlobalTool" /> to <see langword="true" /> to execute MinVer as global tool first and,
+        /// in case of an error, fallback(*) to local tool
+        /// 
+        /// (*) Unless the fallback is disabled via <see cref="NoFallback" />
+        /// 
+        /// Local tool = `dotnet minver`
+        /// Global tool = `minver`
+        /// </summary>
+        public bool PreferGlobalTool { get; set; }
+
+        /// <summary>
+        /// By default, MinVer is executed as a local tool first(*) and, in case of error, fallback to global tool(*)
+        /// Set <see cref="NoFallback" /> to <see langword="true" /> to disable the fallback in case of an error
+        /// 
+        /// (*) Unless <see cref="PreferGlobalTool" /> is set to <see langword="true" />, in which case MinVer is
+        /// executed as a global tool first and, in case of an error, fallback to local tool
+        /// 
+        /// Local tool = `dotnet minver`
+        /// Global tool = `minver`
+        /// </summary>
+        public bool NoFallback { get; set; }
+
+        /// <summary>
         /// Set the verbosity.
         /// --verbosity &lt;VERBOSITY&gt;
         /// error, warn, info (default), debug, or trace

--- a/src/Cake.MinVer/MinVerSettingsExtensions.cs
+++ b/src/Cake.MinVer/MinVerSettingsExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using Cake.Core.IO;
+using Cake.Core.Tooling;
 
 namespace Cake.MinVer
 {
@@ -148,6 +149,72 @@ namespace Cake.MinVer
             }
 
             settings.TagPrefix = tagPrefix;
+
+            return settings;
+        }
+
+        /// <summary>
+        /// By default, MinVer is executed as a local tool first and, in case of error, fallback(*) to global tool
+        /// Set <see cref="MinVerSettings.PreferGlobalTool" /> to <see langword="true" /> to execute MinVer as global tool first and,
+        /// in case of an error, fallback(*) to local tool
+        ///
+        /// (*) Unless the fallback is disabled via <see cref="MinVerSettings.NoFallback" />
+        ///
+        /// Local tool = `dotnet minver`
+        /// Global tool = `minver`
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The <paramref name="settings" /> instance with <see cref="MinVerSettings.Repo" />.</returns>
+        public static MinVerSettings WithPreferGlobalTool(this MinVerSettings settings)
+        {
+            if (settings is null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.PreferGlobalTool = true;
+
+            return settings;
+        }
+
+        /// <summary>
+        /// By default, MinVer is executed as a local tool first(*) and, in case of error, fallback to global tool(*)
+        /// Set <see cref="MinVerSettings.NoFallback" /> to <see langword="true" /> to disable the fallback in case of an error
+        ///
+        /// (*) Unless <see cref="MinVerSettings.PreferGlobalTool" /> is set to <see langword="true" />, in which case MinVer is
+        /// executed as a global tool first and, in case of an error, fallback to local tool
+        ///
+        /// Local tool = `dotnet minver`
+        /// Global tool = `minver`
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The <paramref name="settings" /> instance with <see cref="MinVerSettings.Repo" />.</returns>
+        public static MinVerSettings WithNoFallback(this MinVerSettings settings)
+        {
+            if (settings is null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.NoFallback = true;
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Set a custom path to the minver.exe file.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="toolPath">The custom path to the minver.exe file.</param>
+        /// <returns>The <paramref name="settings" /> instance with <see cref="ToolSettings.ToolPath" /> set to <paramref name="toolPath" />.</returns>
+        public static MinVerSettings WithToolPath(this MinVerSettings settings, FilePath toolPath)
+        {
+            if (settings is null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.ToolPath = toolPath ?? throw new ArgumentNullException(nameof(toolPath));
 
             return settings;
         }

--- a/src/Cake.MinVer/MinVerTool.cs
+++ b/src/Cake.MinVer/MinVerTool.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Linq;
+using System.Globalization;
 using Cake.Common.Tools.DotNetCore;
 using Cake.Core;
 using Cake.Core.Diagnostics;
@@ -13,6 +13,9 @@ namespace Cake.MinVer
     /// </summary>
     public class MinVerTool : DotNetCoreTool<MinVerSettings>
     {
+        private readonly MinVerLocalTool _localTool;
+        private readonly MinVerGlobalTool _globalTool;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MinVerTool" /> class.
         /// </summary>
@@ -26,9 +29,23 @@ namespace Cake.MinVer
             ICakeEnvironment environment,
             IProcessRunner processRunner,
             IToolLocator tools,
-            ICakeLog log) : base(fileSystem, environment, processRunner, tools)
+            ICakeLog log) : this(fileSystem, environment, processRunner, tools, log, localTool: null, globalTool: null)
+        {
+        }
+
+        internal MinVerTool(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools,
+            ICakeLog log,
+            MinVerLocalTool localTool,
+            MinVerGlobalTool globalTool) : base(fileSystem, environment, processRunner, tools)
         {
             CakeLog = log ?? throw new ArgumentNullException(nameof(log));
+
+            _localTool = localTool ?? new MinVerLocalTool(fileSystem, environment, processRunner, tools, log);
+            _globalTool = globalTool ?? new MinVerGlobalTool(fileSystem, environment, processRunner, tools, log);
         }
 
         /// <summary>
@@ -40,6 +57,7 @@ namespace Cake.MinVer
         /// Run the MinVer dotnet tool using the specified settings.
         /// </summary>
         /// <param name="settings">The settings.</param>
+        /// <returns>The MinVer calculated version information</returns>
         public MinVerVersion Run(MinVerSettings settings)
         {
             if (settings is null)
@@ -47,182 +65,67 @@ namespace Cake.MinVer
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            var processSettings = new ProcessSettings
+            if (!(settings.ToolPath is null))
             {
-                RedirectStandardOutput = true,
-            };
+                // If ToolPath is specified, it means it's a global tool in a custom location (also known as a tool-path tool)
+                // https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools
+                settings.PreferGlobalTool = true;
 
-            MinVerVersion minVerVersion = null;
+                // If ToolPath is specified, we try to run that specific tool only... No fallback
+                settings.NoFallback = true;
+            }
 
-            Run(settings, GetArguments(settings), processSettings, p => minVerVersion = ParseVersion(p));
+            MinVerToolBase preferredTool;
+            MinVerToolBase fallbackTool;
 
-            return minVerVersion;
+            if (settings.PreferGlobalTool)
+            {
+                preferredTool = _globalTool;
+                fallbackTool = _localTool;
+            }
+            else
+            {
+                preferredTool = _localTool;
+                fallbackTool = _globalTool;
+            }
+
+            var preferredToolExitCode = preferredTool.TryRun(settings, out var minVerVersion);
+            if (preferredToolExitCode == 0)
+            {
+                return minVerVersion;
+            }
+
+            if (settings.NoFallback)
+            {
+                ProcessExitCode(preferredToolExitCode);
+                return null;
+            }
+
+            var fallbackToolExitCode = fallbackTool.TryRun(settings, out minVerVersion);
+            if (fallbackToolExitCode == 0)
+            {
+                CakeLog.Verbose(string.Format(CultureInfo.InvariantCulture,
+                    "{0}: Process returned an error (exit code {1}), but {2} executed successfully.",
+                    preferredTool.ToolName, preferredToolExitCode, fallbackTool.ToolName));
+
+                ProcessExitCode(fallbackToolExitCode);
+                return minVerVersion;
+            }
+
+            CakeLog.Verbose(string.Format(CultureInfo.InvariantCulture,
+                "{0}: Process returned an error (exit code {1}).", preferredTool.ToolName, preferredToolExitCode));
+
+            CakeLog.Verbose(string.Format(CultureInfo.InvariantCulture,
+                "{0}: Process returned an error (exit code {1}).", fallbackTool.ToolName, fallbackToolExitCode));
+
+            ProcessExitCode(preferredToolExitCode);
+            return null;
         }
 
         /// <inheritdoc />
         protected override string GetToolName()
         {
             return "MinVer";
-        }
-
-        private MinVerVersion ParseVersion(IProcess process)
-        {
-            if (process.GetExitCode() != 0) return null;
-
-            var version = process.GetStandardOutput().LastOrDefault();
-            if (string.IsNullOrWhiteSpace(version))
-            {
-                throw new CakeException($"Version '{version}' is not valid.");
-            }
-
-            try
-            {
-                return new MinVerVersion(version);
-            }
-            catch (Exception ex)
-            {
-                throw new CakeException($"Version '{version}' is not valid.", ex);
-            }
-        }
-
-        private ProcessArgumentBuilder GetArguments(MinVerSettings settings)
-        {
-            var command = new ProcessArgumentBuilder();
-            var args = CreateArgumentBuilder(settings);
-
-            command.Append("minver");
-
-            if (!args.IsNullOrEmpty())
-            {
-                args.CopyTo(command);
-            }
-
-            CakeLog.Verbose("dotnet minver arguments: {0}", args.RenderSafe());
-
-            return command;
-        }
-
-        /// <summary>
-        /// Creates a <see cref="ProcessArgumentBuilder" /> and adds common commandline arguments.
-        /// </summary>
-        /// <param name="settings">The settings.</param>
-        /// <returns>Instance of <see cref="ProcessArgumentBuilder" />.</returns>
-        protected new ProcessArgumentBuilder CreateArgumentBuilder(MinVerSettings settings)
-        {
-            var args = base.CreateArgumentBuilder(settings);
-
-            AppendAutoIncrement(args, settings);
-
-            if (!string.IsNullOrWhiteSpace(settings.BuildMetadata))
-            {
-                args.Append("--build-metadata");
-                args.AppendQuoted(settings.BuildMetadata);
-            }
-
-            if (!string.IsNullOrWhiteSpace(settings.DefaultPreReleasePhase))
-            {
-                args.Append("--default-pre-release-phase");
-                args.AppendQuoted(settings.DefaultPreReleasePhase);
-            }
-
-            if (!string.IsNullOrWhiteSpace(settings.MinimumMajorMinor))
-            {
-                args.Append("--minimum-major-minor");
-                args.AppendQuoted(settings.MinimumMajorMinor);
-            }
-
-            if (!string.IsNullOrWhiteSpace(settings.Repo?.FullPath))
-            {
-                args.Append("--repo");
-                args.AppendQuoted(settings.Repo.FullPath);
-            }
-
-            if (!string.IsNullOrWhiteSpace(settings.TagPrefix))
-            {
-                args.Append("--tag-prefix");
-                args.AppendQuoted(settings.TagPrefix);
-            }
-
-            AppendVerbosity(args, settings);
-
-            return args;
-        }
-
-        private static void AppendAutoIncrement(ProcessArgumentBuilder args, MinVerSettings settings)
-        {
-            switch (settings.AutoIncrement)
-            {
-                case MinVerAutoIncrement.Default:
-                    break;
-
-                case MinVerAutoIncrement.Major:
-                    args.Append("--auto-increment major");
-                    break;
-
-                case MinVerAutoIncrement.Minor:
-                    args.Append("--auto-increment minor");
-                    break;
-
-                case MinVerAutoIncrement.Patch:
-                    args.Append("--auto-increment patch");
-                    break;
-
-                default:
-                    throw new CakeException($"{nameof(settings.AutoIncrement)}={(int)settings.AutoIncrement} is invalid");
-            }
-        }
-
-        private static void AppendVerbosity(ProcessArgumentBuilder args, MinVerSettings settings)
-        {
-            var verbosity = settings.Verbosity;
-            var toolVerbosity = settings.ToolVerbosity;
-
-            if (verbosity == MinVerVerbosity.Default && toolVerbosity.HasValue)
-            {
-                verbosity = ToolToMinVerVerbosityConverter(toolVerbosity.Value);
-            }
-
-            switch (verbosity)
-            {
-                case MinVerVerbosity.Default:
-                    break;
-
-                case MinVerVerbosity.Error:
-                    args.Append("--verbosity error");
-                    break;
-
-                case MinVerVerbosity.Warn:
-                    args.Append("--verbosity warn");
-                    break;
-
-                case MinVerVerbosity.Info:
-                    args.Append("--verbosity info");
-                    break;
-
-                case MinVerVerbosity.Debug:
-                    args.Append("--verbosity debug");
-                    break;
-
-                case MinVerVerbosity.Trace:
-                    args.Append("--verbosity trace");
-                    break;
-
-                default:
-                    throw new CakeException($"{nameof(settings.Verbosity)}={(int)verbosity} is invalid");
-            }
-        }
-
-        private static MinVerVerbosity ToolToMinVerVerbosityConverter(DotNetCoreVerbosity toolVerbosity)
-        {
-            return toolVerbosity switch
-            {
-                DotNetCoreVerbosity.Quiet => MinVerVerbosity.Error,
-                DotNetCoreVerbosity.Minimal => MinVerVerbosity.Warn,
-                DotNetCoreVerbosity.Normal => MinVerVerbosity.Info,
-                DotNetCoreVerbosity.Detailed => MinVerVerbosity.Debug,
-                DotNetCoreVerbosity.Diagnostic => MinVerVerbosity.Trace,
-                _ => MinVerVerbosity.Default
-            };
         }
     }
 }

--- a/src/Cake.MinVer/MinVerToolBase.cs
+++ b/src/Cake.MinVer/MinVerToolBase.cs
@@ -1,0 +1,238 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Common.Tools.DotNetCore;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.MinVer
+{
+    internal abstract class MinVerToolBase : DotNetCoreTool<MinVerSettings>
+    {
+        protected MinVerToolBase(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools,
+            ICakeLog log) : base(fileSystem, environment, processRunner, tools)
+        {
+            CakeLog = log ?? throw new ArgumentNullException(nameof(log));
+        }
+
+        public ICakeLog CakeLog { get; }
+
+        public string ToolName => GetToolName();
+
+        public int TryRun(MinVerSettings settings, out MinVerVersion result)
+        {
+            if (settings is null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            var processSettings = new ProcessSettings
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                Silent = true,
+                RedirectedStandardOutputHandler = output =>
+                {
+                    if (!(output is null))
+                    {
+                        CakeLog.Verbose(output);
+                    }
+
+                    return output;
+                },
+                RedirectedStandardErrorHandler = error =>
+                {
+                    if (!(error is null))
+                    {
+                        CakeLog.Verbose(error);
+                    }
+
+                    return error;
+                },
+            };
+
+            string[] standardOutput = null;
+            MinVerVersion minVerVersion = null;
+            int? exitCode = 1;
+            var minVerArgs = GetArguments(settings);
+
+            try
+            {
+                Run(settings, minVerArgs, processSettings, p =>
+                {
+                    exitCode = p.GetExitCode();
+                    if (exitCode == 0)
+                    {
+                        standardOutput = p.GetStandardOutput().ToArray();
+                    }
+                });
+            }
+            catch (CakeException ex)
+            {
+                CakeLog.Verbose(ex.ToString());
+            }
+
+            if (exitCode == 0)
+            {
+                minVerVersion = ParseVersion(standardOutput);
+            }
+
+            result = minVerVersion;
+            return exitCode.GetValueOrDefault();
+        }
+
+        protected override void ProcessExitCode(int exitCode)
+        {
+            // Do nothing
+        }
+
+        protected abstract ProcessArgumentBuilder GetArguments(MinVerSettings settings);
+
+        /// <summary>
+        /// Creates a <see cref="ProcessArgumentBuilder" /> and adds common commandline arguments.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>Instance of <see cref="ProcessArgumentBuilder" />.</returns>
+        protected new ProcessArgumentBuilder CreateArgumentBuilder(MinVerSettings settings)
+        {
+            var args = base.CreateArgumentBuilder(settings);
+
+            AppendAutoIncrement(args, settings);
+
+            if (!string.IsNullOrWhiteSpace(settings.BuildMetadata))
+            {
+                args.Append("--build-metadata");
+                args.AppendQuoted(settings.BuildMetadata);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.DefaultPreReleasePhase))
+            {
+                args.Append("--default-pre-release-phase");
+                args.AppendQuoted(settings.DefaultPreReleasePhase);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.MinimumMajorMinor))
+            {
+                args.Append("--minimum-major-minor");
+                args.AppendQuoted(settings.MinimumMajorMinor);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.Repo?.FullPath))
+            {
+                args.Append("--repo");
+                args.AppendQuoted(settings.Repo.FullPath);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.TagPrefix))
+            {
+                args.Append("--tag-prefix");
+                args.AppendQuoted(settings.TagPrefix);
+            }
+
+            AppendVerbosity(args, settings);
+
+            return args;
+        }
+
+        private static void AppendAutoIncrement(ProcessArgumentBuilder args, MinVerSettings settings)
+        {
+            switch (settings.AutoIncrement)
+            {
+                case MinVerAutoIncrement.Default:
+                    break;
+
+                case MinVerAutoIncrement.Major:
+                    args.Append("--auto-increment major");
+                    break;
+
+                case MinVerAutoIncrement.Minor:
+                    args.Append("--auto-increment minor");
+                    break;
+
+                case MinVerAutoIncrement.Patch:
+                    args.Append("--auto-increment patch");
+                    break;
+
+                default:
+                    throw new CakeException($"{nameof(settings.AutoIncrement)}={(int)settings.AutoIncrement} is invalid");
+            }
+        }
+
+        private static void AppendVerbosity(ProcessArgumentBuilder args, MinVerSettings settings)
+        {
+            var verbosity = settings.Verbosity;
+            var toolVerbosity = settings.ToolVerbosity;
+
+            if (verbosity == MinVerVerbosity.Default && toolVerbosity.HasValue)
+            {
+                verbosity = ToolToMinVerVerbosityConverter(toolVerbosity.Value);
+            }
+
+            switch (verbosity)
+            {
+                case MinVerVerbosity.Default:
+                    break;
+
+                case MinVerVerbosity.Error:
+                    args.Append("--verbosity error");
+                    break;
+
+                case MinVerVerbosity.Warn:
+                    args.Append("--verbosity warn");
+                    break;
+
+                case MinVerVerbosity.Info:
+                    args.Append("--verbosity info");
+                    break;
+
+                case MinVerVerbosity.Debug:
+                    args.Append("--verbosity debug");
+                    break;
+
+                case MinVerVerbosity.Trace:
+                    args.Append("--verbosity trace");
+                    break;
+
+                default:
+                    throw new CakeException($"{nameof(settings.Verbosity)}={(int)verbosity} is invalid");
+            }
+        }
+
+        private static MinVerVerbosity ToolToMinVerVerbosityConverter(DotNetCoreVerbosity toolVerbosity)
+        {
+            return toolVerbosity switch
+            {
+                DotNetCoreVerbosity.Quiet => MinVerVerbosity.Error,
+                DotNetCoreVerbosity.Minimal => MinVerVerbosity.Warn,
+                DotNetCoreVerbosity.Normal => MinVerVerbosity.Info,
+                DotNetCoreVerbosity.Detailed => MinVerVerbosity.Debug,
+                DotNetCoreVerbosity.Diagnostic => MinVerVerbosity.Trace,
+                _ => MinVerVerbosity.Default
+            };
+        }
+
+        private static MinVerVersion ParseVersion(IEnumerable<string> standardOutput)
+        {
+            var version = standardOutput?.LastOrDefault();
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                throw new CakeException($"Version '{version}' is not valid.");
+            }
+
+            try
+            {
+                return new MinVerVersion(version);
+            }
+            catch (Exception ex)
+            {
+                throw new CakeException($"Version '{version}' is not valid.", ex);
+            }
+        }
+    }
+}

--- a/test/Cake.MinVer.Tests/MinVerGlobalToolTests.cs
+++ b/test/Cake.MinVer.Tests/MinVerGlobalToolTests.cs
@@ -1,0 +1,18 @@
+﻿using Cake.MinVer.Tests.Support;
+using FluentAssertions;
+using Xunit;
+
+namespace Cake.MinVer.Tests
+{
+    public sealed class MinVerGlobalToolTests
+    {
+        [Fact]
+        public void Should_Not_Add_Any_Default_Arguments()
+        {
+            var fixture = new MinVerGlobalToolFixture();
+            var result = fixture.Run();
+
+            result.Args.Should().BeEmpty();
+        }
+    }
+}

--- a/test/Cake.MinVer.Tests/MinVerLocalToolTests.cs
+++ b/test/Cake.MinVer.Tests/MinVerLocalToolTests.cs
@@ -1,0 +1,220 @@
+﻿using System;
+using Cake.Core;
+using Cake.MinVer.Tests.Support;
+using Cake.Testing;
+using FluentAssertions;
+using Xunit;
+
+namespace Cake.MinVer.Tests
+{
+    public sealed class MinVerLocalToolTests
+    {
+        [Fact]
+        public void Should_Throw_If_Settings_Are_Null()
+        {
+            var fixture = new MinVerLocalToolFixture
+            {
+                Settings = null,
+            };
+
+            fixture.GivenDefaultToolDoNotExist();
+
+            fixture.Invoking(f => f.Run())
+                .Should().ThrowExactly<ArgumentNullException>()
+                .And.ParamName.Should().Be("settings");
+        }
+
+        [Fact]
+        public void Should_Add_Mandatory_Arguments()
+        {
+            var fixture = new MinVerLocalToolFixture();
+            var result = fixture.Run();
+
+            result.Args.Should().Be("minver");
+        }
+
+        [Theory]
+        [InlineData(MinVerAutoIncrement.Default, "minver")]
+        [InlineData(MinVerAutoIncrement.Major, "minver --auto-increment major")]
+        [InlineData(MinVerAutoIncrement.Minor, "minver --auto-increment minor")]
+        [InlineData(MinVerAutoIncrement.Patch, "minver --auto-increment patch")]
+        public void Should_Add_Auto_Increment_To_Arguments(MinVerAutoIncrement autoIncrement, string expectedArgs)
+        {
+            var fixture = new MinVerLocalToolFixture
+            {
+                Settings =
+                {
+                    AutoIncrement = autoIncrement,
+                },
+            };
+
+            var result = fixture.Run();
+
+            result.Args.Should().Be(expectedArgs);
+        }
+
+        [Fact]
+        public void Should_Add_Build_Metadata_Arguments()
+        {
+            var fixture = new MinVerLocalToolFixture
+            {
+                Settings =
+                {
+                    BuildMetadata = "1234abc",
+                },
+            };
+
+            var result = fixture.Run();
+
+            result.Args.Should().Be("minver --build-metadata \"1234abc\"");
+        }
+
+        [Fact]
+        public void Should_Add_Default_Pre_Release_Phase_Arguments()
+        {
+            var fixture = new MinVerLocalToolFixture
+            {
+                Settings =
+                {
+                    DefaultPreReleasePhase = "preview",
+                },
+            };
+
+            var result = fixture.Run();
+
+            result.Args.Should().Be("minver --default-pre-release-phase \"preview\"");
+        }
+
+        [Fact]
+        public void Should_Add_Minimum_Major_Minor_Arguments()
+        {
+            var fixture = new MinVerLocalToolFixture
+            {
+                Settings =
+                {
+                    MinimumMajorMinor = "2.0",
+                },
+            };
+
+            var result = fixture.Run();
+
+            result.Args.Should().Be("minver --minimum-major-minor \"2.0\"");
+        }
+
+        [Fact]
+        public void Should_Add_Repo_Arguments()
+        {
+            var fixture = new MinVerLocalToolFixture
+            {
+                Settings =
+                {
+                    Repo = "./src",
+                },
+            };
+
+            var result = fixture.Run();
+
+            result.Args.Should().Be("minver --repo \"src\"");
+        }
+
+        [Fact]
+        public void Should_Add_Tag_Prefix_Arguments()
+        {
+            var fixture = new MinVerLocalToolFixture
+            {
+                Settings =
+                {
+                    TagPrefix = "v",
+                },
+            };
+
+            var result = fixture.Run();
+
+            result.Args.Should().Be("minver --tag-prefix \"v\"");
+        }
+
+        [Theory]
+        [InlineData(MinVerVerbosity.Default, "minver")]
+        [InlineData(MinVerVerbosity.Error, "minver --verbosity error")]
+        [InlineData(MinVerVerbosity.Warn, "minver --verbosity warn")]
+        [InlineData(MinVerVerbosity.Info, "minver --verbosity info")]
+        [InlineData(MinVerVerbosity.Debug, "minver --verbosity debug")]
+        [InlineData(MinVerVerbosity.Trace, "minver --verbosity trace")]
+        public void Should_Add_Verbosity_To_Arguments(MinVerVerbosity verbosity, string expectedArgs)
+        {
+            var fixture = new MinVerLocalToolFixture
+            {
+                Settings =
+                {
+                    Verbosity = verbosity,
+                },
+            };
+
+            var result = fixture.Run();
+
+            result.Args.Should().Be(expectedArgs);
+        }
+
+        [Fact]
+        public void Should_Throw_Cake_Exception_If_Cant_Parse_MinVer_Version()
+        {
+            var fixture = new MinVerLocalToolFixture
+            {
+                StandardOutput = new [] { "abcd" },
+            };
+
+            fixture.Invoking(f => f.Run())
+                .Should().ThrowExactly<CakeException>()
+                .WithMessage("Version 'abcd' is not valid.");
+        }
+
+        [Fact]
+        public void Should_Return_MinVer_Calculated_Version_When_Not_A_Git_Repository()
+        {
+            var fixture = new MinVerLocalToolFixture();
+            var _ = fixture.Run();
+
+            fixture.Result.Version.Should().Be("0.0.0-alpha.0");
+        }
+
+        [Fact]
+        public void Should_Return_MinVer_Calculated_Version_When_Tag_Not_Found()
+        {
+            var fixture = new MinVerLocalToolFixture
+            {
+                StandardOutput = MinVerToolOutputs.OutputWhenTagNotFound,
+            };
+
+            var _ = fixture.Run();
+
+            fixture.Result.Version.Should().Be("0.0.0-alpha.0.42");
+        }
+
+        [Fact]
+        public void Should_Return_MinVer_Calculated_Version_When_Tag_Found_Default_Verbosity()
+        {
+            var fixture = new MinVerLocalToolFixture
+            {
+                StandardOutput = MinVerToolOutputs.OutputWhenTagFoundDefaultVerbosity,
+            };
+
+            var _ = fixture.Run();
+
+            fixture.Result.Version.Should().Be("5.0.1-alpha.0.8");
+        }
+
+
+        [Fact]
+        public void Should_Return_MinVer_Calculated_Version_When_Tag_Found_Verbosity_Error()
+        {
+            var fixture = new MinVerLocalToolFixture
+            {
+                StandardOutput = MinVerToolOutputs.OutputWhenTagFoundVerbosityError,
+            };
+
+            var _ = fixture.Run();
+
+            fixture.Result.Version.Should().Be("1.2.3-preview.0.4");
+        }
+    }
+}

--- a/test/Cake.MinVer.Tests/MinVerSettingsExtensionsTests.cs
+++ b/test/Cake.MinVer.Tests/MinVerSettingsExtensionsTests.cs
@@ -60,6 +60,33 @@ namespace Cake.MinVer.Tests
         }
 
         [Fact]
+        public void Should_Set_PreferGlobalTool_via_WithPreferGlobalTool()
+        {
+            var settings = new MinVerSettings()
+                .WithPreferGlobalTool();
+
+            settings.PreferGlobalTool.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_Set_NoFallback_via_WithNoFallback()
+        {
+            var settings = new MinVerSettings()
+                .WithNoFallback();
+
+            settings.NoFallback.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_Set_ToolPath_via_WithToolPath()
+        {
+            var settings = new MinVerSettings()
+                .WithToolPath(@"c:\myCustomTools\minver.exe");
+
+            settings.ToolPath.FullPath.Should().Be(@"c:/myCustomTools/minver.exe");
+        }
+
+        [Fact]
         public void Should_Set_Verbosity_via_WithVerbosity()
         {
             var settings = new MinVerSettings()

--- a/test/Cake.MinVer.Tests/Support/MinVerGlobalToolFixture.cs
+++ b/test/Cake.MinVer.Tests/Support/MinVerGlobalToolFixture.cs
@@ -1,0 +1,11 @@
+﻿namespace Cake.MinVer.Tests.Support
+{
+    internal class MinVerGlobalToolFixture : MinVerToolFixture<MinVerGlobalTool>
+    {
+        public MinVerGlobalToolFixture(string toolFilename = null)
+            : base(toolFilename ?? "minver.exe")
+        {
+            Tool = new MinVerGlobalTool(FileSystem, Environment, ProcessRunner, Tools, Log);
+        }
+    }
+}

--- a/test/Cake.MinVer.Tests/Support/MinVerLocalToolFixture.cs
+++ b/test/Cake.MinVer.Tests/Support/MinVerLocalToolFixture.cs
@@ -1,0 +1,11 @@
+﻿namespace Cake.MinVer.Tests.Support
+{
+    internal class MinVerLocalToolFixture : MinVerToolFixture<MinVerLocalTool>
+    {
+        public MinVerLocalToolFixture(string toolFilename = null)
+            : base(toolFilename ?? "dotnet.exe")
+        {
+            Tool = new MinVerLocalTool(FileSystem, Environment, ProcessRunner, Tools, Log);
+        }
+    }
+}

--- a/test/Cake.MinVer.Tests/Support/MinVerToolFixture.cs
+++ b/test/Cake.MinVer.Tests/Support/MinVerToolFixture.cs
@@ -4,16 +4,16 @@ using Cake.Core.IO;
 using Cake.Testing;
 using Cake.Testing.Fixtures;
 
-namespace Cake.MinVer.Tests
+namespace Cake.MinVer.Tests.Support
 {
     internal sealed class MinVerToolFixture : ToolFixture<MinVerSettings, ToolFixtureResult>
     {
         private readonly ICakeLog _log = new FakeLog();
 
-        public MinVerToolFixture()
-            : base("dotnet.exe")
+        public MinVerToolFixture(string toolFilename = null)
+            : base(toolFilename ?? "dotnet.exe")
         {
-            ProcessRunner.Process.SetStandardOutput(new[] { "0.0.0-alpha.0" });
+            ProcessRunner.Process.SetStandardOutput(MinVerToolOutputs.OutputWhenNotAGitRepo);
         }
 
         public IEnumerable<string> StandardOutput
@@ -21,10 +21,15 @@ namespace Cake.MinVer.Tests
             set => ProcessRunner.Process.SetStandardOutput(value);
         }
 
+        public MinVerLocalToolFixture LocalTool { private get; set; }
+        public MinVerGlobalToolFixture GlobalTool { private get; set; }
+
+        public MinVerVersion Result { get; private set; }
+
         protected override void RunTool()
         {
-            var tool = new MinVerTool(FileSystem, Environment, ProcessRunner, Tools, _log);
-            tool.Run(Settings);
+            var tool = new MinVerTool(FileSystem, Environment, ProcessRunner, Tools, _log, LocalTool.Tool, GlobalTool.Tool);
+            Result = tool.Run(Settings);
         }
 
         protected override ToolFixtureResult CreateResult(FilePath path, ProcessSettings process)

--- a/test/Cake.MinVer.Tests/Support/MinVerToolFixtureOfT.cs
+++ b/test/Cake.MinVer.Tests/Support/MinVerToolFixtureOfT.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Testing;
+using Cake.Testing.Fixtures;
+
+namespace Cake.MinVer.Tests.Support
+{
+    internal class MinVerToolFixture<T> : ToolFixture<MinVerSettings, ToolFixtureResult>
+        where T : MinVerToolBase
+    {
+        public ICakeLog Log = new FakeLog();
+
+        public MinVerToolFixture(string toolFilename = null)
+            : base(toolFilename ?? "dotnet.exe")
+        {
+            ProcessRunner.Process.SetStandardOutput(MinVerToolOutputs.OutputWhenNotAGitRepo);
+        }
+
+        public IEnumerable<string> StandardOutput
+        {
+            set => ProcessRunner.Process.SetStandardOutput(value);
+        }
+
+        public T Tool { get; protected set; }
+        public MinVerVersion Result { get; private set; }
+
+        protected override void RunTool()
+        {
+            var exitCode = Tool.TryRun(Settings, out var result);
+            Result = exitCode == 0 ? result : null;
+        }
+
+        protected override ToolFixtureResult CreateResult(FilePath path, ProcessSettings process)
+        {
+            return new ToolFixtureResult(path, process);
+        }
+    }
+}

--- a/test/Cake.MinVer.Tests/Support/MinVerToolOutputs.cs
+++ b/test/Cake.MinVer.Tests/Support/MinVerToolOutputs.cs
@@ -1,0 +1,32 @@
+﻿namespace Cake.MinVer.Tests.Support
+{
+    internal static class MinVerToolOutputs
+    {
+        internal static readonly string[] OutputWhenNotAGitRepo =
+        {
+            "MinVer: warning : '.' is not a valid working directory. Using default version 0.0.0-alpha.0.",
+            "MinVer: Calculated version 0.0.0-alpha.0.",
+            "0.0.0-alpha.0",
+        };
+
+        internal static readonly string[] OutputWhenTagNotFound =
+        {
+            "MinVer: No commit found with a valid SemVer 2.0 version. Using default version 0.0.0-alpha.0.",
+            "MinVer: Using { Commit: d34db33, Tag: null, Version: 0.0.0-alpha.0, Height: 42 }.",
+            "MinVer: Calculated version 0.0.0-alpha.0.42.",
+            "0.0.0-alpha.0.42",
+        };
+
+        internal static readonly string[] OutputWhenTagFoundDefaultVerbosity =
+        {
+            "MinVer: Using { Commit: d34db33, Tag: 'v5.0.0', Version: 5.0.0, Height: 8 }.",
+            "MinVer: Calculated version 5.0.1-alpha.0.8.",
+            "5.0.1-alpha.0.8",
+        };
+
+        internal static readonly string[] OutputWhenTagFoundVerbosityError =
+        {
+            "1.2.3-preview.0.4",
+        };
+    }
+}


### PR DESCRIPTION
Closes #5

By default Cake.MinVer:
- Tries to execute MinVer as a local tool (`dotnet minver`)
- If executing the local tool fails, tries to execute as a global tool (`minver`)

Setting `PreferGlobalTool` to `true` tells Cake.MinVer to invert the statement above, i.e.:
- Tries to execute MinVer as a global tool (`minver`)
- If executing the global tool fails, tries to execute as a local tool (`dotnet minver`)

Setting `NoFallback` to `false` disables the fallback logic and Cake.MinVer will only attempt
to execute one of the tools. Which one depends on the value of `PreferGlobalTool`.

N.B.: If `ToolPath` is set
- `PreferGlobalTool` is assumed `true` given that only global tools can have custom paths
- `NoFallback` is assumed `true` given that a specific tool was provided and is expected to exist

Useful information:
https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools